### PR TITLE
import client's custom fields

### DIFF
--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -21,6 +21,10 @@ class Client extends Model
         return $this->hasMany('App\Models\ClientNote', 'client_id', 'client_id');
     }
 
+    public function customfields() {
+        return $this->hasMany('App\Models\ClientCustomField', 'client_id', 'client_id');
+    }
+
     public function quotes() {
         return $this->hasMany('App\Models\Quote', 'client_id', 'client_id');
     }

--- a/app/Models/ClientCustomField.php
+++ b/app/Models/ClientCustomField.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ClientCustomField extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'ip_client_custom';
+
+}

--- a/app/Plane2Ninja/Transformers/BaseTransformer.php
+++ b/app/Plane2Ninja/Transformers/BaseTransformer.php
@@ -96,6 +96,15 @@ class BaseTransformer
         return $formattedString;
     }
 
+    public function formatCustomFields($customFields)
+    {
+        $formattedString = "";
+        foreach($customFields as $cfield)
+            $formattedString .= $cfield->client_custom_fieldvalue;
+
+        return $formattedString;
+    }
+
     public function getContactPhone(Client $client) {
 
         if(isset($client->client_phone))

--- a/app/Plane2Ninja/Transformers/ClientTransformer.php
+++ b/app/Plane2Ninja/Transformers/ClientTransformer.php
@@ -30,8 +30,8 @@ class ClientTransformer extends BaseTransformer
             'id_number' => '',
             'language_id' => 0,
             'currency_id' => 0,
-            'custom_value1' => '',
-            'custom_value2' => '',
+            'custom_value1' => $this->formatCustomFields($client->customfields()->where('client_custom_fieldid', 1)->get()),
+            'custom_value2' => $this->formatCustomFields($client->customfields()->where('client_custom_fieldid', 2)->get()),
             'invoice_number_counter' => 1,
             'quote_number_counter' => 1,
             'contacts' => [


### PR DESCRIPTION
This patch allows to import customer custom fields. 
It can only import fields with id 1 and 2. If there are more custom fields, manual change is needed.
Perhaps better method is needed to have selection of fields to be imported but this works fine in my case.
